### PR TITLE
New 'inherit' options allow color output

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,9 @@ module.exports = function (grunt) {
 
   grunt.initConfig({
     exec: {
-      npm_outdated: 'npm outdated --long --ansi --color'
+      npm_outdated: 'npm outdated --long --ansi --color',
+      stdout: 'inherit',
+      stderr: 'inherit'
     }
   });
 


### PR DESCRIPTION
Default for stdout/stderr is 'pipe' which does not preserve color output.  'inherit' does.

I'll look at supporting stdio: 'inherit' as a shortcut.